### PR TITLE
Fix "Jetpack Compose" previews

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     // Core
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
 

--- a/src/main/java/io/openroad/filetransfer/ble/peripheral/BondedBlePeripherals.kt
+++ b/src/main/java/io/openroad/filetransfer/ble/peripheral/BondedBlePeripherals.kt
@@ -1,97 +1,12 @@
 package io.openroad.filetransfer.ble.peripheral
 
-import android.Manifest
-import android.annotation.SuppressLint
-import android.bluetooth.BluetoothDevice
-import android.content.Context
-import androidx.annotation.RequiresPermission
-import com.adafruit.glider.utils.LogUtils
-import io.openroad.filetransfer.ble.utils.BleManager
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.StateFlow
 
-/**
- * Created by Antonio García (antonio@openroad.es)
- */
-
-
-class BondedBlePeripherals(
-    private val context: Context
-) {
+interface BondedBlePeripherals {
     data class Data(var name: String?, val address: String)
 
-    // Data - Internal
-    private val log by LogUtils()
-    private val _peripheralsData = MutableStateFlow(getPeripheralsData())
+    val peripheralsData: StateFlow<List<Data>>
 
-    // Data - Public
-    val peripheralsData = _peripheralsData.asStateFlow()
-
-    private fun getPeripheralsData(): List<Data> {
-        return try {
-            val bondedDevices = BleManager.getBondedPeripherals(context)
-            bondedDevices?.toList()?.map { Data(name = it.name, address = it.address) }
-                ?: emptyList()
-        } catch (e: SecurityException) {
-            log.warning("bondedDevices security exception: $e")
-            emptyList()
-        }
-    }
-
-    // region Actions
-    fun add(name: String?, address: String) {
-        // The bonded peripheral list is maintained internally by Android but it takes some time until it refreshes. So add it manually
-
-        // If already exist that address, remove it and add it to update the name
-        val peripherals = _peripheralsData.value.toMutableList()
-        val existingPeripheral = peripherals.firstOrNull { it.address == address }
-
-        // Continue if not exist or the name has changed
-        if (existingPeripheral == null || existingPeripheral.name != name) {
-
-            // If the name has changed, remove it to add it with the new name
-            if (existingPeripheral != null) {
-                peripherals.remove(existingPeripheral)
-            }
-
-            peripherals.add(Data(name, address))
-            _peripheralsData.update { peripherals }
-        }
-    }
-
-    fun remove(address: String) {
-        try {
-            val bondedDevices = BleManager.getBondedPeripherals(context)
-            val peripheralData = bondedDevices?.firstOrNull { it.address == address }
-            peripheralData?.let {
-                removeBondedDevice(it)
-
-                // The bonded peripheral list is maintained internally by Android but it takes some time until it refreshes. So remove it manually
-                val peripherals = _peripheralsData.value.toMutableList()
-                val existingPeripheral = peripherals.firstOrNull { it.address == address }
-                if (existingPeripheral != null) {
-                    peripherals.remove(existingPeripheral)
-                    _peripheralsData.update { peripherals }
-                }
-            }
-        } catch (e: SecurityException) {
-            log.warning("remove bonded devices security exception: $e")
-        }
-    }
-
-    fun refresh() {
-        _peripheralsData.update { getPeripheralsData() }
-    }
-
-    fun clear() {
-        BleManager.removeAllBondedPeripheralInfo(context)
-        refresh()
-    }
-
-    private fun removeBondedDevice(device: BluetoothDevice) {
-        BleManager.removeBondedPeripheralInfo(device)
-        refresh()
-    }
-    // endregion
+    fun add(name: String?, address: String)
+    fun remove(address: String)
 }

--- a/src/main/java/io/openroad/filetransfer/ble/peripheral/BondedBlePeripheralsFake.kt
+++ b/src/main/java/io/openroad/filetransfer/ble/peripheral/BondedBlePeripheralsFake.kt
@@ -1,0 +1,25 @@
+package io.openroad.filetransfer.ble.peripheral
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Created by Antonio García (antonio@openroad.es)
+ */
+
+class BondedBlePeripheralsFake() : BondedBlePeripherals {
+    private val _peripheralsData = MutableStateFlow(getPeripheralsData())
+    override val peripheralsData = _peripheralsData.asStateFlow()
+
+    private fun getPeripheralsData(): List<BondedBlePeripherals.Data> {
+        return emptyList()
+    }
+
+    override fun add(name: String?, address: String) {
+
+    }
+
+    override fun remove(address: String) {
+
+    }
+}

--- a/src/main/java/io/openroad/filetransfer/ble/peripheral/BondedBlePeripheralsImpl.kt
+++ b/src/main/java/io/openroad/filetransfer/ble/peripheral/BondedBlePeripheralsImpl.kt
@@ -1,0 +1,97 @@
+package io.openroad.filetransfer.ble.peripheral
+
+import android.bluetooth.BluetoothDevice
+import android.content.Context
+import com.adafruit.glider.utils.LogUtils
+import io.openroad.filetransfer.ble.utils.BleManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Created by Antonio García (antonio@openroad.es)
+ */
+
+class BondedBlePeripheralsImpl(
+    private val context: Context
+): BondedBlePeripherals {
+
+    // Data - Internal
+    private val log by LogUtils()
+    private val _peripheralsData = MutableStateFlow(getPeripheralsData())
+
+    // Data - Public
+    override val peripheralsData = _peripheralsData.asStateFlow()
+
+    private fun getPeripheralsData(): List<BondedBlePeripherals.Data> {
+        return try {
+            val bondedDevices = BleManager.getBondedPeripherals(context)
+            bondedDevices?.toList()?.map {
+                BondedBlePeripherals.Data(
+                    name = it.name,
+                    address = it.address
+                )
+            }
+                ?: emptyList()
+        } catch (e: SecurityException) {
+            log.warning("bondedDevices security exception: $e")
+            emptyList()
+        }
+    }
+
+    // region Actions
+    override fun add(name: String?, address: String) {
+        // The bonded peripheral list is maintained internally by Android but it takes some time until it refreshes. So add it manually
+
+        // If already exist that address, remove it and add it to update the name
+        val peripherals = _peripheralsData.value.toMutableList()
+        val existingPeripheral = peripherals.firstOrNull { it.address == address }
+
+        // Continue if not exist or the name has changed
+        if (existingPeripheral == null || existingPeripheral.name != name) {
+
+            // If the name has changed, remove it to add it with the new name
+            if (existingPeripheral != null) {
+                peripherals.remove(existingPeripheral)
+            }
+
+            peripherals.add(BondedBlePeripherals.Data(name, address))
+            _peripheralsData.update { peripherals }
+        }
+    }
+
+    override fun remove(address: String) {
+        try {
+            val bondedDevices = BleManager.getBondedPeripherals(context)
+            val peripheralData = bondedDevices?.firstOrNull { it.address == address }
+            peripheralData?.let { bluetoothDevice ->
+                removeBondedDevice(bluetoothDevice)
+
+                // The bonded peripheral list is maintained internally by Android but it takes some time until it refreshes. So remove it manually
+                val peripherals = _peripheralsData.value.toMutableList()
+                val existingPeripheral = peripherals.firstOrNull { it.address == address }
+                if (existingPeripheral != null) {
+                    peripherals.remove(existingPeripheral)
+                    _peripheralsData.update { peripherals }
+                }
+            }
+        } catch (e: SecurityException) {
+            log.warning("remove bonded devices security exception: $e")
+        }
+    }
+
+    fun refresh() {
+        _peripheralsData.update { getPeripheralsData() }
+    }
+
+    fun clear() {
+        BleManager.removeAllBondedPeripheralInfo(context)
+        refresh()
+    }
+
+    private fun removeBondedDevice(device: BluetoothDevice) {
+        BleManager.removeBondedPeripheralInfo(device)
+        refresh()
+    }
+    // endregion
+}


### PR DESCRIPTION
JetPack Compose previews can't reference the Bluetooth API.
Created a fake BondedBlePeripheral class for previews that doesn't use BleManager. 